### PR TITLE
Added instruction to change baud rate on the fly

### DIFF
--- a/bootloaders/BoardConfig.h
+++ b/bootloaders/BoardConfig.h
@@ -3127,7 +3127,7 @@
     //*    Clock control settings
     #pragma config IESO         = ON                                // Internal/external clock switchover
     #pragma config FCKSM        = CSDCMD                            // Clock switching (CSx)/Clock monitor (CMx)
-    #pragma config OSCIOFNC     = ON                               // Clock output on OSCO pin enable
+    #pragma config OSCIOFNC     = OFF                               // Clock output on OSCO pin enable
 
     //*    Other Peripheral Device settings
     #pragma config FWDTEN       = OFF                               // Watchdog timer enable


### PR DESCRIPTION
It is now possible to change the baud rate on the fly with a special (non STK500 standard) command.  This allows much faster uploading of large sketches to bigger chips while still maintaining backwards compatibility with avrdude's slow speeds.  pic32prog has also been updated to support the new function.

Speeds at up to 2Mbps have been achieved in testing.